### PR TITLE
Add car state and fix car

### DIFF
--- a/CarRental.sol
+++ b/CarRental.sol
@@ -91,14 +91,7 @@ contract CarRental {
 
     function isCarAvailable(string memory carPlate) public view carExists(carPlate) returns (bool) {
         Car storage car = carMap[carPlate];
-        bool isAvailable;
-        if(car.state == State.Available){
-            isAvailable = true;
-        }else if(car.state == State.Unavailable){
-            isAvailable = false;
-        }
-        return isAvailable;
-        // return !car.isRented;
+        return car.state == State.Available;
     }
 
     function rentCar(string memory carPlate) external carExists(carPlate) {
@@ -127,8 +120,6 @@ contract CarRental {
 
     function returnCar(string memory carPlate) external {
         Car storage car = carMap[carPlate];
-
-        // require(car.isRented, "Car is not rented.");
         require(car.user == msg.sender, "You are not the renter of this car.");
 
         bool isDamaged = damageCheck();

--- a/CarRental.sol
+++ b/CarRental.sol
@@ -141,7 +141,7 @@ contract CarRental {
         if (isDamaged) {
             damageFee = car.price / 2;
             refundAmount -= damageFee;
-            emit CarLog(carPlate, "is damaged")
+            emit CarLog(carPlate, "is damaged");
         }else{
             car.state = State.Available;
         }
@@ -157,9 +157,10 @@ contract CarRental {
         require(carPlates.length > 0, "No cars are available.");
         for (uint256 i = 0; i < carPlates.length; i++) {
             Car storage car = carMap[carPlates[i]];
-            if(car.user == owner & car.state == State.Unavailable){
+            if(car.user == owner && car.state == State.Unavailable){
                 car.state = State.Available;
-                emit CarLog(car.carPlate, "is fixed")
+                emit CarLog(car.carPlate, "is fixed");
             }
+        }
     }
-
+}

--- a/CarRental.sol
+++ b/CarRental.sol
@@ -23,10 +23,11 @@ contract CarRental {
 
     // Events for logging
     event CarAdded(string carPlate, uint256 deposit, uint256 price);
+    event CarLog(string carPlate, string message);
     event CarDetails(string carPlate, State state, uint256 deposit, uint256 price, address user);
 
-    event CarRented(string carPlate, address indexed renter);
-    event CarReturned(string carPlate, address indexed renter, bool isDamaged, uint256 refundAmount, uint256 damageFee);
+    event CarRented(string carPlate, address indexed user);
+    event CarReturned(string carPlate, address indexed user, State state, uint256 refundAmount, uint256 damageFee);
 
     constructor(ERC20 _token) {
         owner = msg.sender;
@@ -140,6 +141,7 @@ contract CarRental {
         if (isDamaged) {
             damageFee = car.price / 2;
             refundAmount -= damageFee;
+            emit CarLog(carPlate, "is damaged")
         }else{
             car.state = State.Available;
         }
@@ -148,6 +150,16 @@ contract CarRental {
         car.user = owner;
 
 
-        emit CarReturned(carPlate, msg.sender, isDamaged, refundAmount, damageFee);
+        emit CarReturned(carPlate, msg.sender, car.state, refundAmount, damageFee);
     }
-}
+
+    function fixCars() external onlyOwner{
+        require(carPlates.length > 0, "No cars are available.");
+        for (uint256 i = 0; i < carPlates.length; i++) {
+            Car storage car = carMap[carPlates[i]];
+            if(car.user == owner & car.state == State.Unavailable){
+                car.state = State.Available;
+                emit CarLog(car.carPlate, "is fixed")
+            }
+    }
+


### PR DESCRIPTION
This branch add three features(State, `fixCars`, `CarLog`) and some changes in `struct Car` in `CarRental.sol`
1. Add 2 states (Available, Unavailable) for `Car` in the contract to replace `isDamaged` and `isRented`. Both of them are considered as `Unavailable` and vice versa.
2. Change `rentalAddress` to `user`. 
    - When a car is new added, its `user` is assigned to the `owner`.  
    - When a car is rented, its `user` is changed to the renter(`msg.sender`).
    -  When a rented car is returned, its `user` is changed back to the `owner`. 
3. If the `state` is `Unavailable` and the `user` is `owner`, it means the car is damaged.
4. The `fixCars` function is declared `onlyOwner`. It is used to fix all damaged cars.
5. The `CarLog` event is emitted when the car is damaged and fixed.